### PR TITLE
feat: add demo csv page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,11 +1,6 @@
 "use client";
-import { createClient } from "@supabase/supabase-js";
 import { useState } from "react";
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+import { supabase } from "@/lib/supabaseClient";
 
 export default function AuthPage() {
   const [email, setEmail] = useState("");

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,12 +2,13 @@ import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import ChurnDashboard from "@/components/ChurnDashboard";
 import Link from "next/link";
+import { supabaseUrl, supabaseAnonKey } from "@/lib/supabaseClient";
 
 export default async function DashboardPage() {
   const cookieStore = cookies();
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     { cookies: { get: (key: string) => cookieStore.get(key)?.value } }
   );
 

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Papa from 'papaparse';
+
+type Row = Record<string, string>;
+
+export default function DemoPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+
+  useEffect(() => {
+    fetch('/demo.csv')
+      .then((res) => res.text())
+      .then((text) => {
+        const parsed = Papa.parse<Row>(text, { header: true });
+        setRows(parsed.data.filter((row) => Object.keys(row).length > 1));
+      });
+  }, []);
+
+  if (!rows.length) {
+    return <p>Loading demo data...</p>;
+  }
+
+  const headers = Object.keys(rows[0]);
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-full text-sm text-left">
+        <thead>
+          <tr>
+            {headers.map((h) => (
+              <th key={h} className="px-2 py-1 border-b">{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="odd:bg-slate-50">
+              {headers.map((h) => (
+                <td key={h} className="px-2 py-1 border-b">{row[h]}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ export default function Page() {
         </ul>
         <div className="flex gap-3 pt-2">
           <Link href="/dashboard" className="px-4 py-2 rounded-xl bg-slate-900 text-white">Go to dashboard</Link>
+          <Link href="/demo" className="px-4 py-2 rounded-xl border border-slate-200 bg-white">View demo</Link>
           <a href="/demo.csv" className="px-4 py-2 rounded-xl border border-slate-200 bg-white">Download demo CSV</a>
         </div>
       </div>

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing Supabase environment variables");
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabaseUrl, supabaseAnonKey };


### PR DESCRIPTION
## Summary
- add a shared Supabase client module with env var checks
- reuse the shared client in auth and dashboard pages
- add a public demo page that loads and displays a sample CSV
- configure ESLint to use Next.js defaults

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898fd17b2fc832f80f8aee6c104e9f3